### PR TITLE
nginx::config first before nginx

### DIFF
--- a/manifests/unicorn.pp
+++ b/manifests/unicorn.pp
@@ -45,11 +45,11 @@ class puppet::unicorn (
   $upstream,
   $backend_process_number,
 ) inherits puppet::params {
-  include nginx
   class { 'nginx::config':
     worker_processes => $::processorcount,
     multi_accept     => 'on',
   }
+  include nginx
   # if this is provided we install the package from the repo, otherwise we build unicorn from scratch
   if $unicorn_package {
     package {$unicorn_package:


### PR DESCRIPTION
Apologies for overlooking the duplicate declaration. This should fix that

based from :
http://stackoverflow.com/questions/28810153/puppet-configuration-for-multiple-classes-in-a-module